### PR TITLE
Avoid crash when no app can open an external link

### DIFF
--- a/app/src/main/java/io/github/sykoram/sis/MainActivity.kt
+++ b/app/src/main/java/io/github/sykoram/sis/MainActivity.kt
@@ -1,6 +1,7 @@
 package io.github.sykoram.sis
 
 import android.app.DownloadManager
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.graphics.Bitmap
 import android.net.Uri
@@ -28,7 +29,11 @@ class MainActivity : AppCompatActivity() {
                 return false
             }
 
-            startActivity(Intent(Intent.ACTION_VIEW, request.url))
+            try {
+                startActivity(Intent(Intent.ACTION_VIEW, request.url))
+            } catch (e: ActivityNotFoundException) {
+                Toast.makeText(applicationContext, R.string.no_app_to_open_link, Toast.LENGTH_LONG).show()
+            }
             return true
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,4 +20,5 @@
     <string name="button_browser_description">Otevřít v prohlížeči</string>
     <string name="button_refresh_description">Znovu načíst</string>
     <string name="downloading_file">Stahování…</string>
+    <string name="no_app_to_open_link">Žádná aplikace pro otevření tohoto odkazu</string>
 </resources>


### PR DESCRIPTION
`MainActivity` opens out of scope links with `startActivity`. On a device with no matching app this throws `ActivityNotFoundException` and crashes the app.

This wraps the launch in a try/catch and shows a short message when nothing can open the link. Allowed pages still load in the WebView as before.

Closes #3
